### PR TITLE
Safe extract2d

### DIFF
--- a/changes/8964.extract_2d.rst
+++ b/changes/8964.extract_2d.rst
@@ -1,0 +1,1 @@
+Wrap process_slit in try/except during extract_2d.nirspec.nrs_extract2d.

--- a/jwst/extract_2d/nirspec.py
+++ b/jwst/extract_2d/nirspec.py
@@ -87,9 +87,10 @@ def nrs_extract2d(input_model, slit_name=None):
                     input_model, slit, exp_type
                 )
             except ValueError:
-                log.warning("process_slit failed for slit/subarray "
-                            "{0}".format(slit.name)
-                            ", probably because the cutout has no valid pixels")
+                log.warning(
+                    'process_slit failed for slit/subarray {0}, '.format(slit.name)
+                    + 'probably because the cutout has no valid pixels'
+                )
                 continue
 
             slits.append(new_model)

--- a/jwst/extract_2d/nirspec.py
+++ b/jwst/extract_2d/nirspec.py
@@ -82,7 +82,15 @@ def nrs_extract2d(input_model, slit_name=None):
 
         # Loop over all slit instances that are present
         for slit in open_slits:
-            new_model, xlo, xhi, ylo, yhi = process_slit(input_model, slit, exp_type)
+            try:
+                new_model, xlo, xhi, ylo, yhi = process_slit(
+                    input_model, slit, exp_type
+                )
+            except ValueError:
+                log.warning("process_slit failed for slit/subarray "
+                            "{0}".format(slit.name)
+                            ", probably because the cutout has no valid pixels")
+                continue
 
             slits.append(new_model)
             orig_s_region = new_model.meta.wcsinfo.s_region.strip()

--- a/jwst/lib/set_telescope_pointing.py
+++ b/jwst/lib/set_telescope_pointing.py
@@ -431,8 +431,6 @@ class TransformParameters:
     dry_run: bool = False
     #: URL of the engineering telemetry database REST interface.
     engdb_url: str | None = None
-    #: MAST_TOKEN
-    mast_token: str = None
     #: Exposure type
     exp_type: str | None = None
     #: FGS to use as the guiding FGS. If None, will be set to what telemetry provides.
@@ -483,7 +481,6 @@ class TransformParameters:
         self.pointing = get_pointing(self.obsstart, self.obsend,
                                      mnemonics_to_read=self.method.mnemonics,
                                      engdb_url=self.engdb_url,
-                                     mast_token=self.mast_token,
                                      tolerance=self.tolerance, reduce_func=self.reduce_func)
 
 
@@ -684,7 +681,7 @@ def update_mt_kwds(model):
 
 
 def update_wcs(model, default_pa_v3=0., default_roll_ref=0., siaf_path=None, prd=None, engdb_url=None,
-               mast_token=None, fgsid=None, tolerance=60, allow_default=False,
+               fgsid=None, tolerance=60, allow_default=False,
                reduce_func=None, **transform_kwargs):
     """Update WCS pointing information
 
@@ -753,7 +750,6 @@ def update_wcs(model, default_pa_v3=0., default_roll_ref=0., siaf_path=None, prd
     t_pars = t_pars_from_model(
         model,
         default_pa_v3=default_pa_v3, engdb_url=engdb_url,
-        mast_token=mast_token,
         tolerance=tolerance, allow_default=allow_default,
         reduce_func=reduce_func, siaf_db=siaf_db, useafter=useafter,
         **transform_kwargs
@@ -1017,7 +1013,6 @@ def calc_wcs_over_time(obsstart, obsend, t_pars: TransformParameters):
     # Calculate WCS
     try:
         pointings = get_pointing(obsstart, obsend, engdb_url=t_pars.engdb_url,
-                                 mast_token=t_pars.mast_token,
                                  tolerance=t_pars.tolerance, reduce_func=t_pars.reduce_func)
     except ValueError:
         logger.warning("Cannot get valid engineering mnemonics from engineering database")
@@ -1692,7 +1687,7 @@ def calc_position_angle(point, ref):
 
 
 def get_pointing(obsstart, obsend, mnemonics_to_read=TRACK_TR_202111_MNEMONICS,
-                 engdb_url=None, mast_token=None, tolerance=60, reduce_func=None):
+                 engdb_url=None, tolerance=60, reduce_func=None):
     """
     Get telescope pointing engineering data.
 
@@ -1703,9 +1698,6 @@ def get_pointing(obsstart, obsend, mnemonics_to_read=TRACK_TR_202111_MNEMONICS,
 
     engdb_url : str or None
         URL of the engineering telemetry database REST interface.
-
-    mast_token : str or None
-        Optional MAST_TOKEN for initializing the engineering db connection.
 
     mnemonics_to_read: {str: bool[,...]}
         The mnemonics to read. Key is the mnemonic name.
@@ -1748,8 +1740,7 @@ def get_pointing(obsstart, obsend, mnemonics_to_read=TRACK_TR_202111_MNEMONICS,
     logger.info('Reduction function: %s', reduce_func)
 
     mnemonics = get_mnemonics(obsstart, obsend, mnemonics_to_read=mnemonics_to_read,
-                              tolerance=tolerance, engdb_url=engdb_url,
-                              mast_token=mast_token)
+                              tolerance=tolerance, engdb_url=engdb_url)
     reduced = reduce_func(mnemonics_to_read, mnemonics)
 
     logger.log(DEBUG_FULL, 'Mnemonics found:')
@@ -1862,7 +1853,7 @@ def _roll_angle_from_matrix(matrix, v2, v3):
     return new_roll
 
 
-def get_mnemonics(obsstart, obsend, tolerance, mnemonics_to_read=TRACK_TR_202111_MNEMONICS, engdb_url=None, mast_token=None):
+def get_mnemonics(obsstart, obsend, tolerance, mnemonics_to_read=TRACK_TR_202111_MNEMONICS, engdb_url=None):
     """Retrieve pointing mnemonics from the engineering database
 
     Parameters
@@ -1894,7 +1885,7 @@ def get_mnemonics(obsstart, obsend, tolerance, mnemonics_to_read=TRACK_TR_202111
 
     """
     try:
-        engdb = ENGDB_Service(base_url=engdb_url, token=mast_token)
+        engdb = ENGDB_Service(base_url=engdb_url)
     except Exception as exception:
         raise ValueError(
             'Cannot open engineering DB connection'


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-nnnn](https://jira.stsci.edu/browse/JP-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses ...

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `Build 11.3` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
- ``changes/<PR#>.docs.rst``
- ``changes/<PR#>.stpipe.rst``
- ``changes/<PR#>.datamodels.rst``
- ``changes/<PR#>.scripts.rst``
- ``changes/<PR#>.fits_generator.rst``
- ``changes/<PR#>.set_telescope_pointing.rst``
- ``changes/<PR#>.pipeline.rst``

## stage 1
- ``changes/<PR#>.group_scale.rst``
- ``changes/<PR#>.dq_init.rst``
- ``changes/<PR#>.emicorr.rst``
- ``changes/<PR#>.saturation.rst``
- ``changes/<PR#>.ipc.rst``
- ``changes/<PR#>.firstframe.rst``
- ``changes/<PR#>.lastframe.rst``
- ``changes/<PR#>.reset.rst``
- ``changes/<PR#>.superbias.rst``
- ``changes/<PR#>.refpix.rst``
- ``changes/<PR#>.linearity.rst``
- ``changes/<PR#>.rscd.rst``
- ``changes/<PR#>.persistence.rst``
- ``changes/<PR#>.dark_current.rst``
- ``changes/<PR#>.charge_migration.rst``
- ``changes/<PR#>.jump.rst``
- ``changes/<PR#>.clean_flicker_noise.rst``
- ``changes/<PR#>.ramp_fitting.rst``
- ``changes/<PR#>.gain_scale.rst``

## stage 2
- ``changes/<PR#>.assign_wcs.rst``
- ``changes/<PR#>.badpix_selfcal.rst``
- ``changes/<PR#>.msaflagopen.rst``
- ``changes/<PR#>.nsclean.rst``
- ``changes/<PR#>.imprint.rst``
- ``changes/<PR#>.background.rst``
- ``changes/<PR#>.extract_2d.rst``
- ``changes/<PR#>.master_background.rst``
- ``changes/<PR#>.wavecorr.rst``
- ``changes/<PR#>.srctype.rst``
- ``changes/<PR#>.straylight.rst``
- ``changes/<PR#>.wfss_contam.rst``
- ``changes/<PR#>.flatfield.rst``
- ``changes/<PR#>.fringe.rst``
- ``changes/<PR#>.pathloss.rst``
- ``changes/<PR#>.barshadow.rst``
- ``changes/<PR#>.photom.rst``
- ``changes/<PR#>.pixel_replace.rst``
- ``changes/<PR#>.resample_spec.rst``
- ``changes/<PR#>.residual_fringe.rst``
- ``changes/<PR#>.cube_build.rst``
- ``changes/<PR#>.extract_1d.rst``
- ``changes/<PR#>.resample.rst``

## stage 3
- ``changes/<PR#>.assign_mtwcs.rst``
- ``changes/<PR#>.mrs_imatch.rst``
- ``changes/<PR#>.tweakreg.rst``
- ``changes/<PR#>.skymatch.rst``
- ``changes/<PR#>.exp_to_source.rst``
- ``changes/<PR#>.outlier_detection.rst``
- ``changes/<PR#>.tso_photometry.rst``
- ``changes/<PR#>.stack_refs.rst``
- ``changes/<PR#>.align_refs.rst``
- ``changes/<PR#>.klip.rst``
- ``changes/<PR#>.spectral_leak.rst``
- ``changes/<PR#>.source_catalog.rst``
- ``changes/<PR#>.combine_1d.rst``
- ``changes/<PR#>.ami.rst``

## other
- ``changes/<PR#>.wfs_combine.rst``
- ``changes/<PR#>.white_light.rst``
- ``changes/<PR#>.cube_skymatch.rst``
- ``changes/<PR#>.engdb_tools.rst``
- ``changes/<PR#>.guider_cds.rst``
</details>
